### PR TITLE
switch to hex encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 # dat-encoding
 
-[Dat](http://dat-data.com/)'s way of encoding and decoding dat links. Pretty similar to base36!
+[Dat](http://dat-data.com/)'s way of encoding and decoding dat links.
 
 [![Build Status](https://travis-ci.org/juliangruber/dat-encoding.svg?branch=master)](https://travis-ci.org/juliangruber/dat-encoding)
 
@@ -10,7 +10,7 @@
 ```js
 var encoding = require('dat-encoding')
 
-var link = '2fdiu7i6kpzx4h9qos6eqldjghd2ut5hx0e8bekm0bkwiax3dt'
+var link = '6161616161616161616161616161616161616161616161616161616161616161'
 var buf = encoding.decode(link)
 console.log('%s -> %s', link, buf)
 console.log('%s -> %s', buf, encoding.encode(buf))
@@ -20,13 +20,11 @@ console.log('%s -> %s', buf, encoding.encode(buf))
 
 ### .encode(buf[, opts])
 
-Encode `buf` into a string that works well in urls. Throws if `buf` isn't 32 bytes of length.
-
-Pass `legacy: true` to create an old style hex encoded link.
+Encode `buf` into a hex string. Throws if `buf` isn't 32 bytes of length.
 
 ### .decode(str)
 
-Decode `str` into its binary representation. If `str` is a 64 character legacy link, simply applies hex decoding. Also supports `dat://` and `dat.com/` links. Throws if the raw link isn't 64 bytes of base64 or 50 bytes of base36.
+Decode `str` into its binary representation. Also supports `dat://` and `dat.com/` links. Throws if the raw link isn't 64 bytes of base64.
 
 ## License
 

--- a/index.js
+++ b/index.js
@@ -1,29 +1,13 @@
 'use strict'
 
-var baseX = require('base-x')
 var Buffer = require('safe-buffer').Buffer
-
-var alphabet = '0123456789abcdefghijklmnopqrstuvwxyz'
-var encoding = baseX(alphabet)
 
 exports.encode = function (buf, opts) {
   if (buf.length !== 32) throw new Error('Invalid buffer')
-  buf = Buffer.from(buf)
-  if (opts && opts.legacy) return buf.toString('hex')
-  var str = encoding.encode(buf)
-  while (str.length < 50) str = '0' + str
-  return str
+  return Buffer.from(buf).toString('hex')
 }
 
 exports.decode = function (str) {
-  return decode(str, true)
-}
-
-function decode (str, checkLength) {
   str = str.slice(str.lastIndexOf('/') + 1)
-  if (/[0-9a-f]{64}/i.test(str)) return Buffer.from(str, 'hex')
-  if (checkLength && str.length !== 50) throw new Error('Invalid key')
-  var buf = Buffer.from(encoding.decode(str))
-  if (buf.length > 32) return decode(str.slice(1, str.length), false)
-  return buf
+  return Buffer.from(str, 'hex')
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "repository": "juliangruber/dat-encoding",
   "description": "Encode and decode Dat links",
   "dependencies": {
-    "base-x": "^1.0.4",
     "safe-buffer": "^5.0.1"
   },
   "devDependencies": {

--- a/test.js
+++ b/test.js
@@ -3,57 +3,36 @@ var enc = require('./')
 
 test('encode', function (t) {
   t.equal(typeof enc.encode(Buffer('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')), 'string')
-  t.equal(enc.encode(Buffer('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')), '2fdiu7i6kpzx4h9qos6eqldjghd2ut5hx0e8bekm0bkwiax3dt')
-  t.equal(enc.encode('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'), '2fdiu7i6kpzx4h9qos6eqldjghd2ut5hx0e8bekm0bkwiax3dt')
+  t.equal(enc.encode(Buffer('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')), '6161616161616161616161616161616161616161616161616161616161616161')
+  t.equal(enc.encode('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'), '6161616161616161616161616161616161616161616161616161616161616161')
   t.throws(function () { enc.encode('tooshort') })
-  t.equal(enc.encode(Buffer('0100000000000000ffffffff0000000000008004010000004012800201000000', 'hex')), '00waum9lsz88rt2zltcysggj4yc0odk8uwwrq05shegvktfgu8')
-
-  t.test('legacy: true', function (t) {
-    t.equal(
-      enc.encode(Buffer('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')).length,
-      50
-    )
-    t.equal(
-      enc.encode(
-        Buffer('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'),
-        { legacy: true }
-      ).length,
-      64
-    )
-    t.end()
-  })
+  t.equal(enc.encode(Buffer('0100000000000000ffffffff0000000000008004010000004012800201000000', 'hex')), '0100000000000000ffffffff0000000000008004010000004012800201000000')
   t.end()
 })
 
 test('decode', function (t) {
-  t.ok(Buffer.isBuffer(enc.decode('42n3t42n3t42n3t42n3t42n3t42n3t42n3t42n3t42n3t42n3t')))
+  t.ok(Buffer.isBuffer(enc.decode('6161616161616161616161616161616161616161616161616161616161616161')))
   t.deepEqual(
-    enc.decode('2fdiu7i6kpzx4h9qos6eqldjghd2ut5hx0e8bekm0bkwiax3dt'),
+    enc.decode('6161616161616161616161616161616161616161616161616161616161616161'),
     Buffer('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')
   )
   t.deepEqual(
-    enc.decode('http://dat.land/2fdiu7i6kpzx4h9qos6eqldjghd2ut5hx0e8bekm0bkwiax3dt'),
+    enc.decode('http://dat.land/6161616161616161616161616161616161616161616161616161616161616161'),
     Buffer('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')
   )
   t.deepEqual(
-    enc.decode('https://dat.land/2fdiu7i6kpzx4h9qos6eqldjghd2ut5hx0e8bekm0bkwiax3dt'),
+    enc.decode('https://dat.land/6161616161616161616161616161616161616161616161616161616161616161'),
     Buffer('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')
   )
   t.deepEqual(
-    enc.decode('dat://2fdiu7i6kpzx4h9qos6eqldjghd2ut5hx0e8bekm0bkwiax3dt'),
+    enc.decode('dat://6161616161616161616161616161616161616161616161616161616161616161'),
     Buffer('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')
   )
-
-  var legacy = {
-    raw: Buffer('abcdabcdbacdbacdbacdbacdbacdbacd'),
-    encoded: '6162636461626364626163646261636462616364626163646261636462616364'
-  }
-  t.deepEqual(enc.decode(legacy.encoded), legacy.raw, 'legacy hex encoding')
 
   t.throws(function () { enc.decode('too short') })
 
   t.deepEqual(
-    enc.decode('00waum9lsz88rt2zltcysggj4yc0odk8uwwrq05shegvktfgu8'),
+    enc.decode('0100000000000000ffffffff0000000000008004010000004012800201000000'),
     Buffer('0100000000000000ffffffff0000000000008004010000004012800201000000', 'hex')
   )
 


### PR DESCRIPTION
The base36 links haven't really been used so let's just switch to a pure hex implementation.

cc @karissa @joehand @mafintosh 