### PR TITLE
handle dat links with trailing slash (closes #12)

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ exports.encode = function (buf, opts) {
 }
 
 exports.decode = function (str) {
+  str = str.replace(/\/$/, '')
   str = str.slice(str.lastIndexOf('/') + 1)
   if (str.length !== 64) throw new Error('Invalid key')
   return Buffer.from(str, 'hex')

--- a/test.js
+++ b/test.js
@@ -28,6 +28,10 @@ test('decode', function (t) {
     enc.decode('dat://6161616161616161616161616161616161616161616161616161616161616161'),
     Buffer('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')
   )
+  t.deepEqual(
+    enc.decode('dat://6161616161616161616161616161616161616161616161616161616161616161/'),
+    Buffer('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')
+  )
 
   t.throws(function () { enc.decode('100') }) // too short
   t.throws(function () { enc.decode('invalid characters') })


### PR DESCRIPTION
Copying links from beaker includes a trailing slash. If present, this will remove that slash so we can handle those.

Closes #12 