### PR TITLE
add convenience methods .to{Buf,Str}, add id

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,19 @@ console.log('%s -> %s', buf, encoding.encode(buf))
 
 ## API
 
-### .encode(buf[, opts])
+### .encode(buf)
+### .toStr(buf)
 
 Encode `buf` into a hex string. Throws if `buf` isn't 32 bytes of length.
 
+If `buf` is already a string, checks if it's valid and returns it.
+
 ### .decode(str)
+### .toBuf(str)
 
 Decode `str` into its binary representation. Also supports `dat://` and `dat.com/` links. Throws if the raw link isn't 64 bytes of base64.
+
+If `str` is already a buffer, checks if it's valid and returns it.
 
 ## License
 

--- a/index.js
+++ b/index.js
@@ -2,13 +2,18 @@
 
 var Buffer = require('safe-buffer').Buffer
 
-exports.encode = function (buf, opts) {
+function encode (buf) {
+  if (typeof buf === 'string') return encode(decode(buf))
   if (buf.length !== 32) throw new Error('Invalid buffer')
   return Buffer.from(buf).toString('hex')
 }
 
-exports.decode = function (str) {
+function decode (str) {
+  if (Buffer.isBuffer(str)) return decode(encode(str))
   var match = /(?:[a-z]+:\/\/(?:dat\.land\/)?)?([^/]{64})/.exec(str)
   if (!match) throw new Error('Invalid key')
   return Buffer.from(match[1], 'hex')
 }
+
+exports.encode = exports.toBuf = encode
+exports.decode = exports.toStr = decode

--- a/test.js
+++ b/test.js
@@ -4,9 +4,9 @@ var enc = require('./')
 test('encode', function (t) {
   t.equal(typeof enc.encode(Buffer('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')), 'string')
   t.equal(enc.encode(Buffer('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')), '6161616161616161616161616161616161616161616161616161616161616161')
-  t.equal(enc.encode('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'), '6161616161616161616161616161616161616161616161616161616161616161')
   t.throws(function () { enc.encode('tooshort') })
   t.equal(enc.encode(Buffer('0100000000000000ffffffff0000000000008004010000004012800201000000', 'hex')), '0100000000000000ffffffff0000000000008004010000004012800201000000')
+  t.equal(enc.encode, enc.toBuf)
   t.end()
 })
 
@@ -40,6 +40,8 @@ test('decode', function (t) {
     enc.decode('0100000000000000ffffffff0000000000008004010000004012800201000000'),
     Buffer('0100000000000000ffffffff0000000000008004010000004012800201000000', 'hex')
   )
+
+  t.equal(enc.decode, enc.toStr)
 
   t.end()
 })


### PR DESCRIPTION
This adds `toStr` and `toBuf` as aliases, and returns the same value if it's already de-/encoded.

closes #15