### PR TITLE
Extracting validation logic to prevent unnecessary double processing

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,21 +2,29 @@
 
 var Buffer = require('safe-buffer').Buffer
 
-function encode (buf) {
-  if (typeof buf === 'string') return encode(decode(buf))
-  if (!Buffer.isBuffer(buf)) throw new Error('Not a buffer')
-  if (buf.length !== 32) throw new Error('Invalid buffer')
-  return buf.toString('hex')
-}
-
-function decode (str) {
-  if (Buffer.isBuffer(str)) return decode(encode(str))
-  if (typeof str !== 'string') throw new Error('Not a string')
+function validateString (str) {
   // looking for an hexa string of 64 or 65 consecutive chars
   var match = /([a-f0-9]{64,65})/i.exec(str)
   // we need exactly 64, so an hexa string with 65 chars (or more) is not allowed
   if (!match || match[1].length !== 64) throw new Error('Invalid key')
-  return Buffer.from(match[1], 'hex')
+  return match[1]
+}
+
+function validateBuffer (buf) {
+  if (buf.length !== 32) throw new Error('Invalid buffer')
+  return buf
+}
+
+function encode (buf) {
+  if (typeof buf === 'string') return validateString(buf)
+  if (!Buffer.isBuffer(buf)) throw new Error('Not a buffer')
+  return validateBuffer(buf).toString('hex')
+}
+
+function decode (str) {
+  if (Buffer.isBuffer(str)) return validateBuffer(str)
+  if (typeof str !== 'string') throw new Error('Not a string')
+  return Buffer.from(validateString(str), 'hex')
 }
 
 exports.encode = exports.toStr = encode


### PR DESCRIPTION
Currently in case a string is passed-in to `encode` or a Buffer is passed-in to `decode` it will do an additional en/decoding step. This PR prevents the unnecessary creation of intermediate Strings/Buffers by extracting the validation logic into own functions.